### PR TITLE
build fbx for macOS and Linux

### DIFF
--- a/.github/workflows/fbx.yml
+++ b/.github/workflows/fbx.yml
@@ -2,17 +2,19 @@ name: AssetStudioFBXNative
 
 on:
   push:
-    branches: [ master ]
+    branches: [ cross ]
   pull_request:
-    branches: [ master ]
+    branches: [ cross ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   # Set a user agent for wget to be able to download the installation packages
   USER_AGENT: "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0"
+  FBX_VERSION_DOT: "2020.2.1"
   FBX_VERSION_DASH: "2020-2-1"
   FBX_VERSION: "202021"
+  VS: 'vs2019' # for windows
 
 defaults:
   run:
@@ -27,11 +29,25 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        architecture: ['x86', 'x64']
-
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        architecture: ['x86', 'x64', 'aarch64']
+        exclude:
+          - os: 'ubuntu-latest' # FBX offers no support for linux x arm64
+            architecture: 'aarch64'
+          - os: 'macos-latest' # Apple dropped support for i363 with XCode 9.4
+            architecture: 'x86'
+    
     steps:
     - uses: actions/checkout@v2
+
+    - name: Install Autodesk FBX (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        curl -L -H "user-agent: ${{ env.USER_AGENT }}" https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/${{ env.FBX_VERSION_DASH }}/${{ env.INSTALLER }} --output ${{ env.INSTALLER }}
+        Start-Process -Wait .\${{ env.INSTALLER }} -ArgumentList '/S'
+        del ${{ env.INSTALLER }}
+      env:
+        INSTALLER: 'fbx${{ env.FBX_VERSION }}_fbxsdk_${{ env.VS }}_win.exe'
 
     - name: Install Autodesk FBX (Mac)
       if: runner.os == 'macOS'
@@ -59,24 +75,100 @@ jobs:
         INSTALLER: 'fbx${{ env.FBX_VERSION }}_fbxsdk_linux'
         ZIP: 'fbx${{ env.FBX_VERSION }}_fbxsdk_linux.tar.gz'
 
-    - name: Configure CMake (macOS)
-      if: runner.os == 'macOS'
+    - name: Configure CMake (Windows x64)
+      if: runner.os == 'Windows' && matrix.architecture == 'x64'
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='/Applications/Autodesk/FBX SDK/2020.2.1/include' -DFBX_LIB='/Applications/Autodesk/FBX SDK/2020.2.1/lib/clang/release' ${{github.workspace}}/AssetStudioFBXNative
+      run: cmake -A x64 -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='${{ env.FBX_SDK }}\include' -DFBX_LIB='${{ env.FBX_SDK }}\lib\${{ env.VS }}\${{ env.ARCH }}\release' ${{github.workspace}}/AssetStudioFBXNative
+      env:
+        FBX_SDK: 'C:\Program Files\Autodesk\FBX\FBX SDK\${{ env.FBX_VERSION_DOT }}'
+        ARCH: '${{ matrix.architecture }}'
+      
+    - name: Configure CMake (Windows x86/win32)
+      if: runner.os == 'Windows' && matrix.architecture == 'x86'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -A win32 -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='${{ env.FBX_SDK }}\include' -DFBX_LIB='${{ env.FBX_SDK }}\lib\${{ env.VS }}\${{ env.ARCH }}\release' ${{github.workspace}}/AssetStudioFBXNative
+      env:
+        FBX_SDK: 'C:\Program Files\Autodesk\FBX\FBX SDK\${{ env.FBX_VERSION_DOT }}'
+        ARCH: '${{ matrix.architecture }}'
 
-    - name: Configure CMake (Linux)
-      if: runner.os == 'Linux'
+    - name: Configure CMake (Windows aarch64)
+      if: runner.os == 'Windows' && matrix.architecture == 'aarch64'
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/AssetStudioFBXNative
+      run: cmake -A arm64 -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='${{ env.FBX_SDK }}\include' -DFBX_LIB='${{ env.FBX_SDK }}\lib\${{ env.VS }}\${{ env.ARCH }}\release' ${{github.workspace}}/AssetStudioFBXNative
+      env:
+        FBX_SDK: 'C:\Program Files\Autodesk\FBX\FBX SDK\${{ env.FBX_VERSION_DOT }}'
+        ARCH: 'arm64'
+
+    - name: Setup XCode Legacy (macOS x86)
+      if: runner.os == 'macOS' && matrix.architecture == 'x86'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: |
+        git clone https://github.com/devernay/xcodelegacy.git
+        cd xcodelegacy
+        chmod +x XcodeLegacy.sh
+        sudo ./XcodeLegacy.sh buildpackages
+        sudo ./XcodeLegacy.sh install
+        cd ..
+
+    - name: Configure CMake (macOS x86)
+      if: runner.os == 'macOS' && matrix.architecture == 'x86'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_OSX_ARCHITECTURES="i386" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='${{ env.FBX_SDK }}/include' -DFBX_LIB='${{ env.FBX_SDK }}/lib/clang/release' ${{github.workspace}}/AssetStudioFBXNative
+      env:
+        FBX_SDK: '/Applications/Autodesk/FBX SDK/${{ env.FBX_VERSION_DOT }}'
+    
+    - name: Configure CMake (macOS x86_64)
+      if: runner.os == 'macOS' && matrix.architecture == 'x64'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='${{ env.FBX_SDK }}/include' -DFBX_LIB='${{ env.FBX_SDK }}/lib/clang/release' ${{github.workspace}}/AssetStudioFBXNative
+      env:
+        FBX_SDK: '/Applications/Autodesk/FBX SDK/${{ env.FBX_VERSION_DOT }}'
+    
+    - name: Configure CMake (macOS arm64)
+      if: runner.os == 'macOS' && matrix.architecture == 'aarch64'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='${{ env.FBX_SDK }}/include' -DFBX_LIB='${{ env.FBX_SDK }}/lib/clang/release' ${{github.workspace}}/AssetStudioFBXNative
+      env:
+        FBX_SDK: '/Applications/Autodesk/FBX SDK/${{ env.FBX_VERSION_DOT }}'
+
+    - name: Configure CMake (Linux x86)
+      if: runner.os == 'Linux' && matrix.architecture == 'x86'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: |
+        sudo apt-get -y install gcc-multilib g++-multilib
+        sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DMXX='m32' -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/AssetStudioFBXNative
+        
+    - name: Configure CMake (Linux x64)
+      if: runner.os == 'Linux' && matrix.architecture == 'x64'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DMXX='m64' -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/AssetStudioFBXNative
+
+    - name: Build (Windows)
+      if: runner.os == 'Windows'
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Build
+      if: runner.os != 'Windows'
       # Build your program with the given configuration
       run: sudo cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Install
+      if: runner.os != 'Windows'
       run: sudo cmake --install ${{github.workspace}}/build
+
+    - name: Install (Windows)
+      if: runner.os == 'Windows'
+      run: cmake --install ${{github.workspace}}/build
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/fbx.yml
+++ b/.github/workflows/fbx.yml
@@ -1,0 +1,114 @@
+name: AssetStudioFBXNative
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  # Set a user agent for wget to be able to download the installation packages
+  USER_AGENT: "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0"
+  FBX_VERSION_DASH: "2020-2-1"
+  FBX_VERSION: "202021"
+
+defaults:
+  run:
+    working-directory: AssetStudioFBXNative
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        architecture: ['x86', 'x64']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Autodesk FBX (Mac)
+      if: runner.os == 'macOS'
+      run: |
+        wget --user-agent="${{ env.USER_AGENT }}" https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/${{ env.FBX_VERSION_DASH }}/${{ env.ZIP }}
+        tar -xzf ${{ env.ZIP }} --directory ./
+        sudo installer -pkg ./${{ env.INSTALLER }} -target /
+        rm ${{ env.INSTALLER }}
+        rm ${{ env.ZIP }}
+      env:
+        INSTALLER: 'fbx${{ env.FBX_VERSION }}_fbxsdk_clang_macos.pkg'
+        ZIP: 'fbx${{ env.FBX_VERSION }}_fbxsdk_clang_mac.pkg.tgz'
+
+    - name: Install Autodesk FBX (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        wget --user-agent="${{ env.USER_AGENT }}" https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/${{ env.FBX_VERSION_DASH }}/${{ env.ZIP }}
+        tar -xzf ${{ env.ZIP }} --directory ./
+        sudo chmod ugo+x ./${{ env.INSTALLER }}
+        yes yes | sudo ./${{ env.INSTALLER }} /usr
+        rm ${{ env.INSTALLER }}
+        rm ${{ env.ZIP }}
+        rm Install_FbxSdk.txt
+      env:
+        INSTALLER: 'fbx${{ env.FBX_VERSION }}_fbxsdk_linux'
+        ZIP: 'fbx${{ env.FBX_VERSION }}_fbxsdk_linux.tar.gz'
+
+    - name: Configure CMake (macOS)
+      if: runner.os == 'macOS'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DFBX_INCLUDE='/Applications/Autodesk/FBX SDK/2020.2.1/include' -DFBX_LIB='/Applications/Autodesk/FBX SDK/2020.2.1/lib/clang/release' ${{github.workspace}}/AssetStudioFBXNative
+
+    - name: Configure CMake (Linux)
+      if: runner.os == 'Linux'
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: sudo cmake -B ${{github.workspace}}/build -D CMAKE_INSTALL_LIBDIR=${{github.workspace}}/lib -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/AssetStudioFBXNative
+
+    - name: Build
+      # Build your program with the given configuration
+      run: sudo cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Install
+      run: sudo cmake --install ${{github.workspace}}/build
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: AssetStudioFBXNative-${{ matrix.os }}-${{ matrix.architecture }}-${{ env.BUILD_TYPE }}
+        path: ${{github.workspace}}/lib/*
+  
+  publish:
+    runs-on: ubuntu-latest
+
+    needs: [ build ]
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Download all workflow run artifacts
+      uses: actions/download-artifact@v2
+
+    - name: Copy dlls to lib
+      run: |
+        mkdir -p lib/${{ matrix.architecture }}
+        cp ${{github.workspace}}/AssetStudioFBXNative-*-Release/* ./lib/${{ matrix.architecture }}/
+    
+    - name: Build nuget package
+      run: dotnet pack AssetStudioFBXNative.csproj -c Release
+
+    - name: Authenticate with nuget
+      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/KiruyaMomochi/index.json"
+
+    - name: Publish nuget package
+      run: |
+        [xml]$solution = Get-Content ./AssetStudioFBXNative.csproj
+        $version = $solution.Project.PropertyGroup.Version
+        dotnet nuget push "bin/Release/Kyaru.AssetStudioFBXNative.$version.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source github
+      shell: pwsh

--- a/AssetStudioFBXNative/CMakeLists.txt
+++ b/AssetStudioFBXNative/CMakeLists.txt
@@ -19,14 +19,16 @@ target_include_directories(AssetStudioFBXNative PRIVATE
 
 IF(APPLE)
 target_link_libraries(AssetStudioFBXNative
-    PRIVATE optimized ${FBX_LIB}/libfbxsdk.dylib
+    PUBLIC optimized ${FBX_LIB}/libfbxsdk.dylib
 )
 ELSEIF(WIN32)
 target_link_libraries(AssetStudioFBXNative 
-    PRIVATE optimized ${FBX_LIB}/libfbxsdk-md.lib 
-    PRIVATE optimized ${FBX_LIB}/libxml2-md.lib
-    PRIVATE optimized ${FBX_LIB}/zlib-md.lib
+    PUBLIC optimized ${FBX_LIB}/libfbxsdk-md.lib 
+    PUBLIC optimized ${FBX_LIB}/libxml2-md.lib
+    PUBLIC optimized ${FBX_LIB}/zlib-md.lib
 )
+ELSEIF(UNIX) # already excluded apple
+set_target_properties(AssetStudioFBXNative PROPERTIES COMPILE_FLAGS -${MXX} LINK_FLAGS -${MXX})
 ENDIF()
 # Ubuntu version installs to /usr -> linker automatically finds it
 

--- a/AssetStudioFBXNative/CMakeLists.txt
+++ b/AssetStudioFBXNative/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.13)
+project(AssetStudioFBXNative)
+set(CMAKE_CXX_STANDARD 17)
+
+add_compile_definitions(DLL_EXPORTS _AS_DLL)
+
+add_library(AssetStudioFBXNative SHARED 
+            api.cpp
+            asfbx_anim_context.cpp
+            asfbx_context.cpp
+            asfbx_morph_context.cpp
+            asfbx_skin_context.cpp
+            utils.cpp)
+
+target_include_directories(AssetStudioFBXNative PRIVATE 
+    ${PROJECT_SOURCE_DIR}
+    ${FBX_INCLUDE}
+)
+
+IF(APPLE)
+target_link_libraries(AssetStudioFBXNative
+    PRIVATE optimized ${FBX_LIB}/libfbxsdk.dylib
+)
+ELSEIF(WIN32)
+target_link_libraries(AssetStudioFBXNative 
+    PRIVATE optimized ${FBX_LIB}/libfbxsdk-md.lib 
+    PRIVATE optimized ${FBX_LIB}/libxml2-md.lib
+    PRIVATE optimized ${FBX_LIB}/zlib-md.lib
+)
+ENDIF()
+# Ubuntu version installs to /usr -> linker automatically finds it
+
+
+install(TARGETS AssetStudioFBXNative DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Hello,
since you're already working on making the libs available cross platform,
I might as well add my part for the fbx version.

The workflow and CMakeList are based on yours for the texture2ddecoder.

Building Linux via a workflow will be a bit tricky,
as the fbx SDK installer for Windows doesn't offer any cli option to install it silently.
The usual tool to extract the contents of installer doesn't work for the fbx installer either.